### PR TITLE
Route generated points to a specific pipeline

### DIFF
--- a/lib/carbon/events.py
+++ b/lib/carbon/events.py
@@ -24,8 +24,6 @@ class Event:
 
 metricReceived = Event('metricReceived')
 metricGenerated = Event('metricGenerated')
-specialMetricReceived = Event('specialMetricReceived')
-specialMetricGenerated = Event('specialMetricGenerated')
 cacheFull = Event('cacheFull')
 cacheSpaceAvailable = Event('cacheSpaceAvailable')
 pauseReceivingMetrics = Event('pauseReceivingMetrics')
@@ -33,7 +31,6 @@ resumeReceivingMetrics = Event('resumeReceivingMetrics')
 
 # Default handlers
 metricReceived.addHandler(lambda metric, datapoint: state.instrumentation.increment('metricsReceived'))
-specialMetricReceived.addHandler(lambda metric, datapoint: state.instrumentation.increment('metricsReceived'))
 
 
 cacheFull.addHandler(lambda: state.instrumentation.increment('cache.overflow'))

--- a/lib/carbon/pipeline.py
+++ b/lib/carbon/pipeline.py
@@ -14,6 +14,12 @@ class Processor(object):
     raise NotImplemented()
 
 
+def run_pipeline_generated(metric, datapoint):
+  # For generated points, use a special pipeline to avoid points
+  # infinitely being trapped.
+  run_pipeline(metric, datapoint, state.pipeline_processors_generated)
+
+
 def run_pipeline(metric, datapoint, processors=None):
   if processors is None:
     processors = state.pipeline_processors

--- a/lib/carbon/state.py
+++ b/lib/carbon/state.py
@@ -8,4 +8,5 @@ cacheTooFull = False
 client_manager = None
 connectedMetricReceiverProtocols = set()
 pipeline_processors = []
+pipeline_processors_generated = []
 database = None

--- a/lib/carbon/tests/test_service.py
+++ b/lib/carbon/tests/test_service.py
@@ -3,7 +3,7 @@ from mock import Mock, patch
 from unittest import TestCase
 
 from carbon import events, state
-from carbon.pipeline import Processor, run_pipeline
+from carbon.pipeline import Processor, run_pipeline, run_pipeline_generated
 from carbon.service import CarbonRootService, setupPipeline
 from carbon.tests.util import TestSettings
 
@@ -27,7 +27,7 @@ class TestSetupPipeline(TestCase):
 
   def test_run_pipeline_chained_to_metric_generated(self):
     setupPipeline([], self.root_service_mock, self.settings)
-    self.assertTrue(run_pipeline in events.metricGenerated.handlers)
+    self.assertTrue(run_pipeline_generated in events.metricGenerated.handlers)
 
   @patch('carbon.service.setupAggregatorProcessor')
   def test_aggregate_processor_set_up(self, setup_mock):


### PR DESCRIPTION
Generated points should not be redirected to the normal
pipeline as this creates infinite loops if, for example, the
name of the aggregated metric is the same as the name of the
original metrics. Instead setup a pipeline that just relays
generate points to the next hop.

This is effectively the behavior of carbon 0.9.*.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo-forks/carbon/3)

<!-- Reviewable:end -->
