### PR TITLE
Use with block to read configuration files

### DIFF
--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -120,11 +120,12 @@ class OrderedConfigParser(ConfigParser):
 
     result = ConfigParser.read(self, path)
     sections = []
-    for line in open(path):
-      line = line.strip()
+    with open(path) as f:
+      for line in f:
+        line = line.strip()
 
-      if line.startswith('[') and line.endswith(']'):
-        sections.append( line[1:-1] )
+        if line.startswith('[') and line.endswith(']'):
+          sections.append( line[1:-1] )
 
     self._ordered_sections = sections
 


### PR DESCRIPTION
This prevents the "too many open files" error.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo-forks/carbon/4)

<!-- Reviewable:end -->
