### PR TITLE
Add debug log to compute usage of carbon aggregation rules

### DIFF
--- a/lib/carbon/aggregator/buffers.py
+++ b/lib/carbon/aggregator/buffers.py
@@ -72,6 +72,7 @@ class MetricBuffer:
         buffer.mark_inactive()
 
       if buffer.interval < age_threshold:
+        log.debug("Aggregated %s datapoints at %s for %s" % (len(buffer.values), buffer.interval, self.metric_path))
         del self.interval_buffers[buffer.interval]
         if not self.interval_buffers:
           self.close()


### PR DESCRIPTION
Log the number of datapoints aggregated inside a buffer when closing it.