### PR TITLE
Added a way to serve a /metrics to be scraped

### DIFF
--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -568,3 +568,8 @@ MAX_AGGREGATION_INTERVALS = 5
 
 # You can optionally set a ttl to this cache.
 # CACHE_METRIC_NAMES_TTL=600
+
+# Set this to True to enable /metrics endpoint
+# use SCRAPE_INTERFACE and SCRAPE_PORT to choose where
+# this endpoint will bind
+# USE_PROMETHEUS = False

--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -100,6 +100,9 @@ defaults = dict(
   METRIC_CLIENT_IDLE_TIMEOUT=None,
   CACHE_METRIC_NAMES_MAX=0,
   CACHE_METRIC_NAMES_TTL=0,
+  USE_PROMETHEUS=False,
+  SCRAPE_INTERFACE='0.0.0.0',
+  SCRAPE_PORT=8080
 )
 
 
@@ -314,7 +317,6 @@ class CarbonCacheOptions(usage.Options):
         pidfile = self.parent["pidfile"]
         program = settings["program"]
         instance = self["instance"]
-
         if action == "stop":
             if not exists(pidfile):
                 print "Pidfile %s does not exist" % pidfile

--- a/lib/carbon/instrumentation.py
+++ b/lib/carbon/instrumentation.py
@@ -25,7 +25,7 @@ lastUsageTime = time.time()
 # more consistent, and make room for frontend metrics.
 #metric_prefix = "Graphite.backend.%(program)s.%(instance)s." % settings
 
-DATAPOINTS_RECEIVED = Counter('datapoints_received_total', 'count of datapoint received by carbon agent')
+DATAPOINTS_RECEIVED = Counter('carbon_datapoints_received_total', 'count of datapoint received by carbon agent')
 
 def increment(stat, increase=1):
   try:
@@ -233,4 +233,3 @@ class CarbonMetricsCollector:
 # Avoid import circularities
 from carbon import state, events, cache
 from carbon.aggregator.buffers import BufferManager
-

--- a/lib/carbon/instrumentation.py
+++ b/lib/carbon/instrumentation.py
@@ -150,7 +150,7 @@ def recordMetrics():
   record('metricsReceived', myStats.get('metricsReceived', 0))
   record('blacklistMatches', myStats.get('blacklistMatches', 0))
   record('whitelistRejects', myStats.get('whitelistRejects', 0))
-  record('cpuUsage',  getCpuUsage())
+  record('cpuUsage', getCpuUsage())
   DATAPOINTS_RECEIVED.inc(myStats.get('metricsReceived', 0))
 
   # And here preserve count of messages received in the prior periiod

--- a/lib/carbon/tests/test_intrumentation.py
+++ b/lib/carbon/tests/test_intrumentation.py
@@ -1,0 +1,25 @@
+from carbon.instrumentation import increment, CarbonMetricsCollector, stats, recordMetrics, DATAPOINTS_RECEIVED
+from prometheus_client import REGISTRY
+from unittest import TestCase
+
+
+class TestPrometheusMetrics(TestCase):
+
+  def setUp(self):
+    # necessary for recordMetric to work
+    from carbon.conf import settings
+    settings['program'] = 'test'
+    settings['instance'] = None
+
+  def test_metricsRecieved(self):
+    stats.clear()
+    increment("metricsReceived")
+    recordMetrics()
+    self.assertCurrentDPValue(1)
+    increment("metricsReceived")
+    self.assertCurrentDPValue(1)
+    recordMetrics()
+    self.assertCurrentDPValue(2)
+
+  def assertCurrentDPValue(self, value):
+    self.assertEqual(value, REGISTRY.get_sample_value('datapoints_received_total'))

--- a/lib/carbon/tests/test_intrumentation.py
+++ b/lib/carbon/tests/test_intrumentation.py
@@ -22,4 +22,4 @@ class TestPrometheusMetrics(TestCase):
     self.assertCurrentDPValue(2)
 
   def assertCurrentDPValue(self, value):
-    self.assertEqual(value, REGISTRY.get_sample_value('datapoints_received_total'))
+    self.assertEqual(value, REGISTRY.get_sample_value('carbon_datapoints_received_total'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Twisted>=13.2.0
 git+git://github.com/graphite-project/whisper.git#egg=whisper
 txAMQP
 cachetools
+prometheus_client


### PR DESCRIPTION
new configuration option on carbon.conf
- USE_PROMETHEUS: set to True to enable the endpoint
- SCRAPE_INTERFACE
- SCRAPE_PORT

Only a subset of metrics are supported:
- metricsReceives (served as datapoints_received_total) 
- cpuUsage (served as cpu_usage_percent) 
- memoryUsage (served as memory_usage_bytes)
- activeConnections (served as  active_connections_total)

metric received are updated periodically when carbon. would flush its metrics (by default 60s) 